### PR TITLE
Correct image size and position of gps text

### DIFF
--- a/components/camera/FullScreenCamera.tsx
+++ b/components/camera/FullScreenCamera.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from 'react'
+import { useWindowDimensions } from 'react-native'
 import { Camera, CameraProps, useCameraDevice, useCameraFormat } from 'react-native-vision-camera'
 
 import { NoDeviceError } from '@/components/camera/NoDeviceError'
@@ -6,15 +7,16 @@ import { useAppState } from '@/hooks/useAppState'
 import { useIsFocused } from '@/hooks/useIsFocused'
 
 const ASPECT_RATIO = 16 / 9
-const width = 360
+const photoWidth = 720
 
 const FullScreenCamera = forwardRef<Camera, Omit<Partial<CameraProps>, 'device'>>((props, ref) => {
   const focused = useIsFocused()
   const appState = useAppState()
+  const { width } = useWindowDimensions()
 
   const device = useCameraDevice('back')
 
-  const resolution = { width, height: width * ASPECT_RATIO }
+  const resolution = { width: photoWidth, height: photoWidth * ASPECT_RATIO }
 
   const format = useCameraFormat(device, [
     {

--- a/state/OffenceStore/useCreateOffence.ts
+++ b/state/OffenceStore/useCreateOffence.ts
@@ -47,7 +47,7 @@ export const useCreateOffence = () => {
           addTextToImage({
             text: coordsToString(location.lat, location.long),
             imagePath: photo,
-            position: Position.bottomLeft,
+            position: Position.topLeft,
           }),
         ),
       )


### PR DESCRIPTION
- proper image size (some devices had 720 and some 360) (closes #90)
- GPS position to top so it won't interfere with time