### PR TITLE
#110 Refactor top attachment with flashlight and fix bottom sheet closing bug

### DIFF
--- a/app/(app)/offence/photos/detail.tsx
+++ b/app/(app)/offence/photos/detail.tsx
@@ -5,10 +5,10 @@ import { Image } from 'react-native'
 import { Camera } from 'react-native-vision-camera'
 
 import CameraBottomSheet from '@/components/camera/CameraBottomSheet'
-import { TorchState } from '@/components/camera/FlashlightBottomSheetAttachment'
 import FullScreenCamera from '@/components/camera/FullScreenCamera'
 import ScreenView from '@/components/screen-layout/ScreenView'
 import IconButton from '@/components/shared/IconButton'
+import FlashlightContextProvider from '@/modules/camera/state/FlashlightContextProvider'
 import { getPhotoUri } from '@/modules/camera/utils/getPhotoUri'
 import { useOffenceStoreContext } from '@/state/OffenceStore/useOffenceStoreContext'
 import { useSetOffenceState } from '@/state/OffenceStore/useSetOffenceState'
@@ -34,7 +34,6 @@ const AppRoute = () => {
     (index ? photos[photoIndex] : zonePhotoUrl) || null,
   )
   const [isRetaking, setIsRetaking] = useState(false)
-  const [torch, setTorch] = useState<TorchState>('off')
   const [loading, setLoading] = useState(false)
 
   const takePicture = async () => {
@@ -72,50 +71,50 @@ const AppRoute = () => {
   }
 
   return (
-    <ScreenView
-      hasBackButton
-      title={t('offence.picture.detail.title')}
-      options={
-        index
-          ? {
-              headerRight: () => (
-                <IconButton
-                  accessibilityLabel={t('offence.picture.detail.retake')}
-                  name="cached"
-                  onPress={retakePicture}
-                />
-              ),
-            }
-          : undefined
-      }
-      className="h-full"
-    >
-      {photo ? (
-        <Image
-          source={{
-            uri: index
-              ? getPhotoUri(photo) || getPhotoUri(photos[photoIndex])
-              : addImageCdnUrl(photo),
-          }}
-          resizeMode="contain"
-          style={{ flex: 1 }}
-        />
-      ) : (
-        <FullScreenCamera ref={ref} torch={torch} />
-      )}
+    <FlashlightContextProvider>
+      <ScreenView
+        hasBackButton
+        title={t('offence.picture.detail.title')}
+        options={
+          index
+            ? {
+                headerRight: () => (
+                  <IconButton
+                    accessibilityLabel={t('offence.picture.detail.retake')}
+                    name="cached"
+                    onPress={retakePicture}
+                  />
+                ),
+              }
+            : undefined
+        }
+        className="h-full"
+      >
+        {photo ? (
+          <Image
+            source={{
+              uri: index
+                ? getPhotoUri(photo) || getPhotoUri(photos[photoIndex])
+                : addImageCdnUrl(photo),
+            }}
+            resizeMode="contain"
+            style={{ flex: 1 }}
+          />
+        ) : (
+          <FullScreenCamera ref={ref} />
+        )}
 
-      {isRetaking ? (
-        <CameraBottomSheet
-          hasPhoto={!!photo}
-          torch={torch}
-          isLoading={loading}
-          takePicture={takePicture}
-          selectPicture={selectPicture}
-          retakePicture={index ? retakePicture : undefined}
-          setTorch={setTorch}
-        />
-      ) : null}
-    </ScreenView>
+        {isRetaking ? (
+          <CameraBottomSheet
+            hasPhoto={!!photo}
+            isLoading={loading}
+            takePicture={takePicture}
+            selectPicture={selectPicture}
+            retakePicture={index ? retakePicture : undefined}
+          />
+        ) : null}
+      </ScreenView>
+    </FlashlightContextProvider>
   )
 }
 

--- a/app/(app)/offence/photos/index.tsx
+++ b/app/(app)/offence/photos/index.tsx
@@ -3,11 +3,11 @@ import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Camera } from 'react-native-vision-camera'
 
-import { TorchState } from '@/components/camera/FlashlightBottomSheetAttachment'
 import FullScreenCamera from '@/components/camera/FullScreenCamera'
 import PhotosBottomSheet from '@/components/camera/PhotosBottomSheet'
 import ScreenView from '@/components/screen-layout/ScreenView'
 import { useSnackbar } from '@/components/screen-layout/Snackbar/useSnackbar'
+import FlashlightContextProvider from '@/modules/camera/state/FlashlightContextProvider'
 import { useOffenceStoreContext } from '@/state/OffenceStore/useOffenceStoreContext'
 import { useSetOffenceState } from '@/state/OffenceStore/useSetOffenceState'
 import { addTextToImage } from '@/utils/addTextToImage'
@@ -22,7 +22,6 @@ const AppRoute = () => {
   const photos = useOffenceStoreContext((state) => state.photos)
 
   const ref = useRef<Camera>(null)
-  const [torch, setTorch] = useState<TorchState>('off')
   const [loading, setLoading] = useState(false)
 
   const takePicture = async () => {
@@ -56,23 +55,20 @@ const AppRoute = () => {
   }
 
   return (
-    <ScreenView
-      hasBackButton
-      title={t('offenceCamera.titleWithCount', {
-        currentCount: photos.length + 1,
-        maxCount: MAX_PHOTOS,
-      })}
-      className="h-full"
-    >
-      <FullScreenCamera ref={ref} torch={torch} />
+    <FlashlightContextProvider>
+      <ScreenView
+        hasBackButton
+        title={t('offenceCamera.titleWithCount', {
+          currentCount: photos.length + 1,
+          maxCount: MAX_PHOTOS,
+        })}
+        className="h-full"
+      >
+        <FullScreenCamera ref={ref} />
 
-      <PhotosBottomSheet
-        torch={torch}
-        isLoading={loading}
-        takePicture={takePicture}
-        setTorch={setTorch}
-      />
-    </ScreenView>
+        <PhotosBottomSheet isLoading={loading} takePicture={takePicture} />
+      </ScreenView>
+    </FlashlightContextProvider>
   )
 }
 

--- a/app/(app)/scan/licence-plate-camera.tsx
+++ b/app/(app)/scan/licence-plate-camera.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import { View } from 'react-native'
 import { Camera } from 'react-native-vision-camera'
 
-import { TorchState } from '@/components/camera/FlashlightBottomSheetAttachment'
 import { LicencePlateCameraBackground } from '@/components/camera/LicencePlateCameraBackground'
 import LicencePlateCameraBottomSheet from '@/components/camera/LicencePlateCameraBottomSheet'
 import OcrCamera from '@/components/camera/OcrCamera'
@@ -13,6 +12,7 @@ import ScreenView from '@/components/screen-layout/ScreenView'
 import DismissKeyboard from '@/components/shared/DissmissKeyboard'
 import { ScanResultEnum } from '@/modules/backend/openapi-generated'
 import { useScanLicencePlate } from '@/modules/camera/hooks/useScanLicencePlate'
+import FlashlightContextProvider from '@/modules/camera/state/FlashlightContextProvider'
 import { TextData } from '@/modules/camera/types'
 import { useOffenceStoreContext } from '@/state/OffenceStore/useOffenceStoreContext'
 import { useSetOffenceState } from '@/state/OffenceStore/useSetOffenceState'
@@ -24,7 +24,6 @@ const REQUIRED_SCANS = 2
 const LicencePlateCameraComp = () => {
   const { t } = useTranslation()
   const ref = useRef<Camera>(null)
-  const [torch, setTorch] = useState<TorchState>('off')
   const [isManual, setIsManual] = useState(false)
 
   const plateHistoryRef = useRef<string[]>([])
@@ -120,30 +119,30 @@ const LicencePlateCameraComp = () => {
   }, [scanResult, onChangeLicencePlate, pathname])
 
   return (
-    <DismissKeyboard>
-      <ScreenView
-        title={t('scanLicencePlate.title')}
-        options={{
-          headerRight: () => <HomeButton />,
-        }}
-        className="h-full"
-      >
-        <View className="relative">
-          <OcrCamera ref={ref} torch={torch} onFrameCapture={onFrameCapture} />
+    <FlashlightContextProvider>
+      <DismissKeyboard>
+        <ScreenView
+          title={t('scanLicencePlate.title')}
+          options={{
+            headerRight: () => <HomeButton />,
+          }}
+          className="h-full"
+        >
+          <View className="relative">
+            <OcrCamera ref={ref} onFrameCapture={onFrameCapture} />
 
-          <LicencePlateCameraBackground />
-        </View>
+            <LicencePlateCameraBackground />
+          </View>
 
-        <LicencePlateCameraBottomSheet
-          isLoading={isLoading}
-          torch={torch}
-          setTorch={setTorch}
-          licencePlate={generatedEcv}
-          onContinue={onContinue}
-          onChangeLicencePlate={onChangeLicencePlate}
-        />
-      </ScreenView>
-    </DismissKeyboard>
+          <LicencePlateCameraBottomSheet
+            isLoading={isLoading}
+            licencePlate={generatedEcv}
+            onContinue={onContinue}
+            onChangeLicencePlate={onChangeLicencePlate}
+          />
+        </ScreenView>
+      </DismissKeyboard>
+    </FlashlightContextProvider>
   )
 }
 

--- a/app/(app)/zone/photo-camera.tsx
+++ b/app/(app)/zone/photo-camera.tsx
@@ -5,12 +5,12 @@ import { useTranslation } from 'react-i18next'
 import { Image } from 'react-native'
 import { Camera } from 'react-native-vision-camera'
 
-import { TorchState } from '@/components/camera/FlashlightBottomSheetAttachment'
 import FullScreenCamera from '@/components/camera/FullScreenCamera'
 import ZoneCameraBottomSheet from '@/components/camera/ZoneCameraBottomSheet'
 import ScreenView from '@/components/screen-layout/ScreenView'
 import { clientApi } from '@/modules/backend/client-api'
 import { getFavouritePhotosOptions } from '@/modules/backend/constants/queryOptions'
+import FlashlightContextProvider from '@/modules/camera/state/FlashlightContextProvider'
 import { useOffenceStoreContext } from '@/state/OffenceStore/useOffenceStoreContext'
 import { useSetOffenceState } from '@/state/OffenceStore/useSetOffenceState'
 import { addGpsMetadataToImage } from '@/utils/addGpsMetadataToImage'
@@ -24,7 +24,6 @@ const AppRoute = () => {
   const zonePhoto = useOffenceStoreContext((state) => state.zonePhoto)
 
   const ref = useRef<Camera>(null)
-  const [torch, setTorch] = useState<TorchState>('off')
   const [loading, setLoading] = useState(false)
 
   const queryClient = useQueryClient()
@@ -88,25 +87,25 @@ const AppRoute = () => {
   console.log(zonePhoto ? createUrlFromImageObject(zonePhoto) : undefined)
 
   return (
-    <ScreenView hasBackButton title={t('zone.zonePicture')} className="h-full">
-      {zonePhoto ? (
-        <Image
-          source={{ uri: createUrlFromImageObject(zonePhoto) }}
-          resizeMode="contain"
-          style={{ flex: 1 }}
-        />
-      ) : (
-        <FullScreenCamera ref={ref} torch={torch} />
-      )}
+    <FlashlightContextProvider>
+      <ScreenView hasBackButton title={t('zone.zonePicture')} className="h-full">
+        {zonePhoto ? (
+          <Image
+            source={{ uri: createUrlFromImageObject(zonePhoto) }}
+            resizeMode="contain"
+            style={{ flex: 1 }}
+          />
+        ) : (
+          <FullScreenCamera ref={ref} />
+        )}
 
-      <ZoneCameraBottomSheet
-        hasPhoto={!!zonePhoto}
-        torch={torch}
-        isLoading={loading}
-        takePicture={takePicture}
-        setTorch={setTorch}
-      />
-    </ScreenView>
+        <ZoneCameraBottomSheet
+          hasPhoto={!!zonePhoto}
+          isLoading={loading}
+          takePicture={takePicture}
+        />
+      </ScreenView>
+    </FlashlightContextProvider>
   )
 }
 

--- a/components/camera/CameraBottomSheet.tsx
+++ b/components/camera/CameraBottomSheet.tsx
@@ -1,17 +1,14 @@
 import BottomSheet from '@gorhom/bottom-sheet'
-import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSharedValue } from 'react-native-reanimated'
 
-import FlashlightBottomSheetAttachment, {
-  FlashLightProps,
-} from '@/components/camera/FlashlightBottomSheetAttachment'
+import FlashlightBottomSheetAttachment from '@/components/camera/FlashlightBottomSheetAttachment'
 import PhotoBottomSheetAttachment from '@/components/camera/PhotoBottomSheetAttachment'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
 import Button from '@/components/shared/Button'
 import Typography from '@/components/shared/Typography'
 
-type Props = FlashLightProps & {
+type Props = {
   isLoading: boolean
   hasPhoto: boolean
   takePicture: () => Promise<void>
@@ -25,10 +22,8 @@ const CameraBottomSheet = ({
   takePicture,
   selectPicture,
   retakePicture,
-  ...rest
 }: Props) => {
   const { t } = useTranslation()
-  const modalRef = useRef<BottomSheet>(null)
 
   const animatedPosition = useSharedValue(0)
 
@@ -42,14 +37,12 @@ const CameraBottomSheet = ({
           />
         ) : null
       ) : (
-        <FlashlightBottomSheetAttachment {...rest} animatedPosition={animatedPosition} />
+        <FlashlightBottomSheetAttachment animatedPosition={animatedPosition} />
       )}
 
       <BottomSheet
         handleComponent={null}
         keyboardBehavior="interactive"
-        ref={modalRef}
-        onClose={modalRef.current?.expand}
         enableDynamicSizing
         animatedPosition={animatedPosition}
       >

--- a/components/camera/FlashlightBottomSheetAttachment.tsx
+++ b/components/camera/FlashlightBottomSheetAttachment.tsx
@@ -1,5 +1,5 @@
 import * as Location from 'expo-location'
-import { Dispatch, ReactNode, SetStateAction } from 'react'
+import { ReactNode } from 'react'
 import { View } from 'react-native'
 
 import BottomSheetTopAttachment, {
@@ -7,21 +7,19 @@ import BottomSheetTopAttachment, {
 } from '@/components/screen-layout/BottomSheet/BottomSheetTopAttachment'
 import FlexRow from '@/components/shared/FlexRow'
 import IconButton from '@/components/shared/IconButton'
+import { useFlashlightContext } from '@/modules/camera/state/useFlashlightContext'
 import { useCameraPermission } from '@/modules/permissions/useCameraPermission'
 
 export type TorchState = 'on' | 'off'
 
-export type FlashLightProps = {
-  torch: TorchState
-  setTorch: Dispatch<SetStateAction<TorchState>>
-}
-
 type Props = Omit<BottomSheetTopAttachmentProps, 'children'> & {
   iconLeft?: ReactNode
-} & FlashLightProps
+}
 
-const FlashlightBottomSheetAttachment = ({ setTorch, iconLeft, torch, ...restProps }: Props) => {
+const FlashlightBottomSheetAttachment = ({ iconLeft, ...restProps }: Props) => {
   const [permissionStatus] = useCameraPermission()
+
+  const { torch, setTorch } = useFlashlightContext()
 
   return (
     <BottomSheetTopAttachment {...restProps}>

--- a/components/camera/FullScreenCamera.tsx
+++ b/components/camera/FullScreenCamera.tsx
@@ -5,6 +5,7 @@ import { Camera, CameraProps, useCameraDevice, useCameraFormat } from 'react-nat
 import { NoDeviceError } from '@/components/camera/NoDeviceError'
 import { useAppState } from '@/hooks/useAppState'
 import { useIsFocused } from '@/hooks/useIsFocused'
+import { useFlashlightContext } from '@/modules/camera/state/useFlashlightContext'
 
 const ASPECT_RATIO = 16 / 9
 const photoWidth = 720
@@ -14,10 +15,10 @@ const FullScreenCamera = forwardRef<Camera, Omit<Partial<CameraProps>, 'device'>
   const appState = useAppState()
   const { width } = useWindowDimensions()
 
+  const { torch } = useFlashlightContext()
   const device = useCameraDevice('back')
 
   const resolution = { width: photoWidth, height: photoWidth * ASPECT_RATIO }
-
   const format = useCameraFormat(device, [
     {
       photoAspectRatio: ASPECT_RATIO,
@@ -33,6 +34,7 @@ const FullScreenCamera = forwardRef<Camera, Omit<Partial<CameraProps>, 'device'>
       ref={ref}
       photo
       format={format}
+      torch={torch}
       onError={(error) => console.error('Camera error', error)}
       device={device}
       style={{ height: width * ASPECT_RATIO }}

--- a/components/camera/LicencePlateCameraBottomSheet.tsx
+++ b/components/camera/LicencePlateCameraBottomSheet.tsx
@@ -1,18 +1,15 @@
 import BottomSheet from '@gorhom/bottom-sheet'
-import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSharedValue } from 'react-native-reanimated'
 
-import FlashlightBottomSheetAttachment, {
-  FlashLightProps,
-} from '@/components/camera/FlashlightBottomSheetAttachment'
+import FlashlightBottomSheetAttachment from '@/components/camera/FlashlightBottomSheetAttachment'
 import Field from '@/components/inputs/Field'
 import TextInput from '@/components/inputs/TextInput'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
 import Button from '@/components/shared/Button'
 import IconButton from '@/components/shared/IconButton'
 
-type Props = FlashLightProps & {
+type Props = {
   licencePlate?: string
   isLoading: boolean
   onContinue: () => Promise<void>
@@ -24,17 +21,14 @@ const LicencePlateCameraBottomSheet = ({
   isLoading,
   onContinue,
   onChangeLicencePlate,
-  ...rest
 }: Props) => {
   const { t } = useTranslation()
-  const modalRef = useRef<BottomSheet>(null)
 
   const animatedPosition = useSharedValue(0)
 
   return (
     <>
       <FlashlightBottomSheetAttachment
-        {...rest}
         animatedPosition={animatedPosition}
         iconLeft={
           licencePlate ? (
@@ -51,8 +45,6 @@ const LicencePlateCameraBottomSheet = ({
       <BottomSheet
         handleComponent={null}
         keyboardBehavior="interactive"
-        ref={modalRef}
-        onClose={modalRef.current?.expand}
         enableDynamicSizing
         animatedPosition={animatedPosition}
       >

--- a/components/camera/PhotosBottomSheet.tsx
+++ b/components/camera/PhotosBottomSheet.tsx
@@ -1,35 +1,29 @@
 import BottomSheet from '@gorhom/bottom-sheet'
-import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSharedValue } from 'react-native-reanimated'
 
-import FlashlightBottomSheetAttachment, {
-  FlashLightProps,
-} from '@/components/camera/FlashlightBottomSheetAttachment'
+import FlashlightBottomSheetAttachment from '@/components/camera/FlashlightBottomSheetAttachment'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
 import Button from '@/components/shared/Button'
 import Typography from '@/components/shared/Typography'
 
-type Props = FlashLightProps & {
+type Props = {
   isLoading: boolean
   takePicture: () => Promise<void>
 }
 
-const PhotosBottomSheet = ({ isLoading, takePicture, ...rest }: Props) => {
+const PhotosBottomSheet = ({ isLoading, takePicture }: Props) => {
   const { t } = useTranslation()
-  const modalRef = useRef<BottomSheet>(null)
 
   const animatedPosition = useSharedValue(0)
 
   return (
     <>
-      <FlashlightBottomSheetAttachment {...rest} animatedPosition={animatedPosition} />
+      <FlashlightBottomSheetAttachment animatedPosition={animatedPosition} />
 
       <BottomSheet
         handleComponent={null}
         keyboardBehavior="interactive"
-        ref={modalRef}
-        onClose={modalRef.current?.expand}
         enableDynamicSizing
         animatedPosition={animatedPosition}
       >

--- a/components/camera/ZoneCameraBottomSheet.tsx
+++ b/components/camera/ZoneCameraBottomSheet.tsx
@@ -1,12 +1,10 @@
 import BottomSheet from '@gorhom/bottom-sheet'
 import { useRouter } from 'expo-router'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSharedValue } from 'react-native-reanimated'
 
-import FlashlightBottomSheetAttachment, {
-  FlashLightProps,
-} from '@/components/camera/FlashlightBottomSheetAttachment'
+import FlashlightBottomSheetAttachment from '@/components/camera/FlashlightBottomSheetAttachment'
 import PhotoBottomSheetAttachment from '@/components/camera/PhotoBottomSheetAttachment'
 import TextInput from '@/components/inputs/TextInput'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
@@ -15,16 +13,15 @@ import Typography from '@/components/shared/Typography'
 import { useOffenceStoreContext } from '@/state/OffenceStore/useOffenceStoreContext'
 import { useSetOffenceState } from '@/state/OffenceStore/useSetOffenceState'
 
-type Props = FlashLightProps & {
+type Props = {
   isLoading: boolean
   hasPhoto: boolean
   takePicture: (tag: string) => Promise<void>
 }
 
-const ZoneCameraBottomSheet = ({ hasPhoto, isLoading, takePicture, ...rest }: Props) => {
+const ZoneCameraBottomSheet = ({ hasPhoto, isLoading, takePicture }: Props) => {
   const { setOffenceState } = useSetOffenceState()
   const { t } = useTranslation()
-  const modalRef = useRef<BottomSheet>(null)
   const router = useRouter()
 
   const zonePhotoTag = useOffenceStoreContext((state) => state.zonePhoto?.tag)
@@ -44,14 +41,12 @@ const ZoneCameraBottomSheet = ({ hasPhoto, isLoading, takePicture, ...rest }: Pr
       {hasPhoto ? (
         <PhotoBottomSheetAttachment animatedPosition={animatedPosition} onRetake={retakePicture} />
       ) : (
-        <FlashlightBottomSheetAttachment {...rest} animatedPosition={animatedPosition} />
+        <FlashlightBottomSheetAttachment animatedPosition={animatedPosition} />
       )}
 
       <BottomSheet
         handleComponent={null}
         keyboardBehavior="interactive"
-        ref={modalRef}
-        onClose={modalRef.current?.expand}
         enableDynamicSizing
         animatedPosition={animatedPosition}
       >

--- a/components/map/MapZoneBottomSheet.tsx
+++ b/components/map/MapZoneBottomSheet.tsx
@@ -1,5 +1,5 @@
 import BottomSheet from '@gorhom/bottom-sheet'
-import { forwardRef, useRef } from 'react'
+import { forwardRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { View } from 'react-native'
 import { useSharedValue } from 'react-native-reanimated'
@@ -10,7 +10,6 @@ import MapZoneBottomSheetPanel from '@/components/map/MapZoneBottomSheetPanel'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
 import BottomSheetHandleWithShadow from '@/components/screen-layout/BottomSheet/BottomSheetHandleWithShadow'
 import Typography from '@/components/shared/Typography'
-import { useMultipleRefsSetter } from '@/hooks/useMultipleRefsSetter'
 import { MapUdrZoneWithTranslationProps } from '@/modules/map/types'
 import { cn } from '@/utils/cn'
 
@@ -22,10 +21,6 @@ type Props = {
 
 const MapZoneBottomSheet = forwardRef<BottomSheet, Props>(
   ({ zone: selectedZone, setFlyToCenter, isZoomedOut }, ref) => {
-    const localRef = useRef<BottomSheet>(null)
-
-    const refSetter = useMultipleRefsSetter(ref, localRef)
-
     const { t } = useTranslation()
     const animatedPosition = useSharedValue(0)
 
@@ -34,14 +29,13 @@ const MapZoneBottomSheet = forwardRef<BottomSheet, Props>(
         <MapZoneBottomSheetAttachment {...{ animatedPosition, setFlyToCenter }} />
         <BottomSheet
           key="mapZoneBottomSheet"
-          ref={refSetter}
+          ref={ref}
           keyboardBehavior="interactive"
           handleComponent={BottomSheetHandleWithShadow}
           animatedPosition={animatedPosition}
-          onClose={localRef.current?.expand}
           enableDynamicSizing
         >
-          <BottomSheetContent isDynamic className={cn('bg-white', selectedZone ? 'g-2' : 'g-3')}>
+          <BottomSheetContent className={cn('bg-white', selectedZone ? 'g-2' : 'g-3')}>
             {isZoomedOut ? (
               <View className="flex-col items-center">
                 <Typography className="text-center">{t('zone.zoomIn')}</Typography>

--- a/components/map/location-map/LocationMapBottomSheet.tsx
+++ b/components/map/location-map/LocationMapBottomSheet.tsx
@@ -1,5 +1,5 @@
 import BottomSheet from '@gorhom/bottom-sheet'
-import { forwardRef, useRef } from 'react'
+import { forwardRef } from 'react'
 import { useSharedValue } from 'react-native-reanimated'
 
 import { MapRef } from '@/components/map/Map'
@@ -7,7 +7,6 @@ import MapZoneBottomSheetAttachment from '@/components/map/MapZoneBottomSheetAtt
 import ContinueButton from '@/components/navigation/ContinueButton'
 import BottomSheetContent from '@/components/screen-layout/BottomSheet/BottomSheetContent'
 import BottomSheetHandleWithShadow from '@/components/screen-layout/BottomSheet/BottomSheetHandleWithShadow'
-import { useMultipleRefsSetter } from '@/hooks/useMultipleRefsSetter'
 
 type Props = {
   isDisabled?: boolean
@@ -17,9 +16,6 @@ type Props = {
 
 const LocationMapBottomSheet = forwardRef<BottomSheet, Props>(
   ({ setFlyToCenter, isDisabled, onPress }, ref) => {
-    const localRef = useRef<BottomSheet>(null)
-    const refSetter = useMultipleRefsSetter(ref, localRef)
-
     const animatedPosition = useSharedValue(0)
 
     return (
@@ -28,14 +24,13 @@ const LocationMapBottomSheet = forwardRef<BottomSheet, Props>(
 
         <BottomSheet
           key="mapZoneBottomSheet"
-          ref={refSetter}
-          onClose={localRef.current?.expand}
+          ref={ref}
           keyboardBehavior="interactive"
           handleComponent={BottomSheetHandleWithShadow}
           animatedPosition={animatedPosition}
           enableDynamicSizing
         >
-          <BottomSheetContent>
+          <BottomSheetContent className="min-h-[80px]">
             <ContinueButton disabled={isDisabled} onPress={onPress} />
           </BottomSheetContent>
         </BottomSheet>

--- a/components/screen-layout/BottomSheet/BottomSheetContent.tsx
+++ b/components/screen-layout/BottomSheet/BottomSheetContent.tsx
@@ -1,20 +1,17 @@
-import { BottomSheetView } from '@gorhom/bottom-sheet'
+import { BottomSheetView, useBottomSheet } from '@gorhom/bottom-sheet'
 import { ComponentProps } from 'react'
 import { SafeAreaView } from 'react-native'
 
 import { cn } from '@/utils/cn'
 
-type Props = ComponentProps<typeof BottomSheetView> & {
-  isDynamic?: boolean
-}
+const BottomSheetContent = ({ children, className }: ComponentProps<typeof BottomSheetView>) => {
+  const { expand } = useBottomSheet()
 
-const BottomSheetContent = ({ children, className, isDynamic }: Props) => {
   return (
     <SafeAreaView>
-      <BottomSheetView className={cn('px-5 py-3', { 'min-h-[80px]': !isDynamic }, className)}>
+      {/* Everytime bottom sheet renders a content it should automatically open the bottom sheet, we use it only as static bottom sheet without the need to close */}
+      <BottomSheetView onLayout={() => expand()} className={cn('px-5 py-3', className)}>
         {children}
-        {/* TODO this should be handled by SafeAreaProvider */}
-        {/* spacer */}
       </BottomSheetView>
     </SafeAreaView>
   )

--- a/components/screen-layout/BottomSheet/BottomSheetTopAttachment.tsx
+++ b/components/screen-layout/BottomSheet/BottomSheetTopAttachment.tsx
@@ -1,6 +1,6 @@
-import { PropsWithChildren, useCallback, useState } from 'react'
-import { LayoutChangeEvent, useWindowDimensions } from 'react-native'
-import Animated, { interpolate, SharedValue, useAnimatedStyle } from 'react-native-reanimated'
+import { PropsWithChildren, useCallback } from 'react'
+import { LayoutChangeEvent } from 'react-native'
+import Animated, { SharedValue, useAnimatedStyle, useSharedValue } from 'react-native-reanimated'
 
 export type BottomSheetTopAttachmentProps = PropsWithChildren & {
   animatedPosition: SharedValue<number>
@@ -10,19 +10,18 @@ const BottomSheetTopAttachment = ({
   children,
   animatedPosition,
 }: BottomSheetTopAttachmentProps) => {
-  const { height: screenHeight } = useWindowDimensions()
-  const [height, setHeight] = useState(0)
-  const animatedStyles = useAnimatedStyle(() => {
-    const translateY = interpolate(animatedPosition.value, [0, screenHeight], [0, screenHeight])
+  const sharedHeight = useSharedValue(0)
 
-    return {
-      transform: [{ translateY: -height }, { translateY }],
-    }
-  })
+  const animatedStyles = useAnimatedStyle(() => ({
+    transform: [{ translateY: -sharedHeight.value }, { translateY: animatedPosition.value }],
+  }))
 
-  const handleLayout = useCallback((event: LayoutChangeEvent) => {
-    setHeight(event.nativeEvent.layout.height)
-  }, [])
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      sharedHeight.value = event.nativeEvent.layout.height
+    },
+    [sharedHeight],
+  )
 
   return (
     <Animated.View

--- a/modules/camera/state/FlashlightContextProvider.tsx
+++ b/modules/camera/state/FlashlightContextProvider.tsx
@@ -1,0 +1,20 @@
+import 'core-js/stable/atob'
+
+import { createContext, Dispatch, PropsWithChildren, SetStateAction, useState } from 'react'
+
+import { TorchState } from '@/components/camera/FlashlightBottomSheetAttachment'
+
+export const FlashlightContext = createContext<{
+  torch: TorchState
+  setTorch: Dispatch<SetStateAction<TorchState>>
+} | null>(null)
+
+const FlashlightContextProvider = ({ children }: PropsWithChildren) => {
+  const [torch, setTorch] = useState<TorchState>('off')
+
+  return (
+    <FlashlightContext.Provider value={{ torch, setTorch }}>{children}</FlashlightContext.Provider>
+  )
+}
+
+export default FlashlightContextProvider

--- a/modules/camera/state/useFlashlightContext.tsx
+++ b/modules/camera/state/useFlashlightContext.tsx
@@ -1,0 +1,13 @@
+import { useContext } from 'react'
+
+import { FlashlightContext } from '@/modules/camera/state/FlashlightContextProvider'
+
+export const useFlashlightContext = () => {
+  const context = useContext(FlashlightContext)
+
+  if (!context) {
+    throw new Error('useFlashlightContext must be used within a FlashlightContextProvider')
+  }
+
+  return context
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@expo-google-fonts/inter": "~0.2.3",
     "@expo/vector-icons": "~14.0.0",
-    "@gorhom/bottom-sheet": "~4.5.1",
+    "@gorhom/bottom-sheet": "~4.6.4",
     "@gorhom/portal": "~1.0.14",
     "@lodev09/react-native-exify": "~0.2.7",
     "@rnmapbox/maps": "10.1.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,10 +1655,10 @@
     find-up "^5.0.0"
     js-yaml "^4.1.0"
 
-"@gorhom/bottom-sheet@~4.5.1":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-4.5.1.tgz#1ac4b234a80e7dff263f0b7ac207f92e41562849"
-  integrity sha512-4Qy6hzvN32fXu2hDxDXOIS0IBGBT6huST7J7+K1V5bXemZ08KIx5ZffyLgwhCUl+CnyeG2KG6tqk6iYLkIwi7Q==
+"@gorhom/bottom-sheet@~4.6.4":
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-4.6.4.tgz#387d0f0f21e3470eb8575498cb81ce96f5108e79"
+  integrity sha512-0itLMblLBvepE065w3a60S030c2rNUsGshPC7wbWDm31VyqoaU2xjzh/ojH62YIJOcobBr5QoC30IxBBKDGovQ==
   dependencies:
     "@gorhom/portal" "1.0.14"
     invariant "^2.2.4"


### PR DESCRIPTION
- add flashlight context to remove same implementation of state across all cameras, 
- refactor bottom sheet top attachment to support new version of react-native-reanimated,
- fix closed state of bottom sheet on mount (we use it as is not intended by library, so some tweaks are necessary) the old approach to expand onClosed stopped working in new version (maybe some different order of init steps) so new approach was necessary

**!!Some of changes in this PR are needed to implement also on PAAS MPA!!**