### PR TITLE
#146 fix the multiclick loading bug

### DIFF
--- a/components/shared/Button.tsx
+++ b/components/shared/Button.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Pressable, PressableProps, View } from 'react-native'
 
@@ -70,24 +70,21 @@ const Button = forwardRef<View, ButtonProps>(
     const rest = { ...restProps, disabled: loading || disabled }
     const { buttonContainerClassNames, buttonTextClassNames } = buttonClassNames(variant, rest)
 
-    return (
+    // Loading check needs to be separated, because when used within Pressable it can trigger onPress when the button is pressed quickly before loading ends or right after loading starts
+    return loading ? (
+      <View className={cn(buttonContainerClassNames)}>
+        <Icon name="hourglass-top" className={buttonTextClassNames} />
+        <Typography variant="button" className={buttonTextClassNames}>
+          {`${loadingText || t('button.loading')}${loadingTextEllipsis ? '…' : ''}`}
+        </Typography>
+      </View>
+    ) : (
       <Pressable ref={ref} hitSlop={4} {...rest} className={cn(buttonContainerClassNames)}>
-        {loading ? (
-          <>
-            <Icon name="hourglass-top" className={buttonTextClassNames} />
-            <Typography variant="button" className={buttonTextClassNames}>
-              {`${loadingText || t('button.loading')}${loadingTextEllipsis ? '…' : ''}`}
-            </Typography>
-          </>
-        ) : (
-          <>
-            {startIcon ? <Icon name={startIcon} className={buttonTextClassNames} /> : null}
-            <Typography variant="button" className={buttonTextClassNames}>
-              {children}
-            </Typography>
-            {endIcon ? <Icon name={endIcon} className={buttonTextClassNames} /> : null}
-          </>
-        )}
+        {startIcon ? <Icon name={startIcon} className={buttonTextClassNames} /> : null}
+        <Typography variant="button" className={buttonTextClassNames}>
+          {children}
+        </Typography>
+        {endIcon ? <Icon name={endIcon} className={buttonTextClassNames} /> : null}
       </Pressable>
     )
   },


### PR DESCRIPTION
the buttons could be clicked multiple times while loading because of how RN works (bridge)

the button is not shown now during loading phase so there is nothing that can be clicked (we show button-like placeholder) 

(mpa has same issue) 