### PR TITLE
Fix change zone modal not closing when the modal's X button is pressed

### DIFF
--- a/components/map/location-map/ChangeZoneModal.tsx
+++ b/components/map/location-map/ChangeZoneModal.tsx
@@ -19,7 +19,7 @@ export const ChangeZoneModal = ({ visible, onCloseModal }: Props) => {
   }
 
   return (
-    <Modal visible={visible}>
+    <Modal visible={visible} onRequestClose={onCloseModal}>
       <ModalContentWithActions
         customAvatarComponent={<AvatarCircleIcon name="map" />}
         title={t('zone.changeModal.title')}

--- a/components/special/StoreVersionControl.tsx
+++ b/components/special/StoreVersionControl.tsx
@@ -41,7 +41,7 @@ const StoreVersionControl = () => {
   }
 
   return (
-    <Modal visible={showModal}>
+    <Modal visible={showModal} onRequestClose={closeModal}>
       <ModalContentWithActions
         customAvatarComponent={<AvatarCircle />}
         title={t('storeVersionControl.title')}


### PR DESCRIPTION
The closing function hook was not provided to the modal that contains the X button